### PR TITLE
fix: fix internal time passing

### DIFF
--- a/projects/ngx-mat-timepicker-repo/src/test.ts
+++ b/projects/ngx-mat-timepicker-repo/src/test.ts
@@ -17,7 +17,13 @@ declare const require: {
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
+  {
+    teardown: {
+      destroyAfterEach: true,
+      rethrowErrors: false,
+    }
+  }
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-content/ngx-mat-timepicker-content.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-content/ngx-mat-timepicker-content.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NgxMatTimepickerContentComponent } from './ngx-mat-timepicker-content.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -7,13 +7,12 @@ describe('NgxMatTimepickerContentComponent', () => {
     let component: NgxMatTimepickerContentComponent;
     let fixture: ComponentFixture<NgxMatTimepickerContentComponent>;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [NgxMatTimepickerContentComponent],
             schemas: [NO_ERRORS_SCHEMA]
-        })
-            .compileComponents();
-    }));
+        });
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(NgxMatTimepickerContentComponent);

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from "@angular/core/testing";
+import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from "@angular/core/testing";
 import {NgxMatTimepickerDialControlComponent} from "./ngx-mat-timepicker-dial-control.component";
 import {NO_ERRORS_SCHEMA} from "@angular/core";
 import {NgxMatTimepickerUnits} from "../../models/ngx-mat-timepicker-units.enum";
@@ -29,7 +29,7 @@ describe("NgxMatTimepickerDialControlComponent", () => {
         component = fixture.componentInstance;
     });
 
-    it("should set current time to previous time, change time unit and emit focus event", async(() => {
+    it("should set current time to previous time, change time unit and emit focus event", waitForAsync(() => {
         let counter = 0;
         component.timeUnitChanged.subscribe(unit => expect(unit).toBe(NgxMatTimepickerUnits.MINUTE));
         component.focused.subscribe(() => expect(++counter).toBe(1));

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.spec.ts
@@ -170,7 +170,7 @@ describe("NgxMatTimepickerDialControlComponent", () => {
             component.minutesGap = 6;
 
             component.onKeydown({...event, keyCode: arrowDown});
-            expect(component.time).toBe("5");
+            expect(component.time).toBe("05");
         });
     });
 

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-face/ngx-mat-timepicker-face.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-face/ngx-mat-timepicker-face.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from "@angular/core/testing";
+import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from "@angular/core/testing";
 import {NgxMatTimepickerFaceComponent} from "./ngx-mat-timepicker-face.component";
 import {ElementRef, NO_ERRORS_SCHEMA, SimpleChanges} from "@angular/core";
 import {NgxMatTimepickerClockFace} from "../../models/ngx-mat-timepicker-clock-face.interface";
@@ -287,7 +287,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             expect(selectedTime).toEqual({time: 1, angle: 5});
         }));
 
-        it("should emit selected time once user stop interaction with clock face", async(() => {
+        it("should emit selected time once user stop interaction with clock face", waitForAsync(() => {
             const mouseCords: MouseEventInit = {clientX: 20, clientY: 20};
 
             component.faceTime = minutesFaceTime;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-face/ngx-mat-timepicker-face.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-face/ngx-mat-timepicker-face.component.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from "@angular/core/testing";
+import {Subscription} from "rxjs";
 import {NgxMatTimepickerFaceComponent} from "./ngx-mat-timepicker-face.component";
 import {ElementRef, NO_ERRORS_SCHEMA, SimpleChanges} from "@angular/core";
 import {NgxMatTimepickerClockFace} from "../../models/ngx-mat-timepicker-clock-face.interface";
@@ -14,8 +15,10 @@ import {NgxMatTimepickerActiveMinutePipe} from "../../pipes/ngx-mat-timepicker-a
 describe("NgxMatTimepickerFaceComponent", () => {
     let fixture: ComponentFixture<NgxMatTimepickerFaceComponent>;
     let component: NgxMatTimepickerFaceComponent;
+    let subscription: Subscription;
 
     beforeEach(() => {
+        subscription = new Subscription();
         fixture = TestBed.configureTestingModule({
             declarations: [
                 NgxMatTimepickerFaceComponent,
@@ -31,6 +34,10 @@ describe("NgxMatTimepickerFaceComponent", () => {
         }).createComponent(NgxMatTimepickerFaceComponent);
 
         component = fixture.componentInstance;
+    });
+
+    afterEach(() => {
+        subscription.unsubscribe();
     });
 
     it("trackByTime should return time", () => {
@@ -123,7 +130,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             }
         };
         let updatedTime: NgxMatTimepickerClockFace = {time: 1, angle: 20};
-        component.timeChange.subscribe(time => updatedTime = time);
+        subscription.add(component.timeChange.subscribe(time => updatedTime = time));
         component.ngOnChanges(changes);
         tick();
         expect(updatedTime).toEqual({time: 12, angle: 30, disabled: false});
@@ -141,7 +148,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             }
         };
         let updatedTime: NgxMatTimepickerClockFace = {time: 1, angle: 20};
-        component.timeChange.subscribe(time => updatedTime = time);
+        subscription.add(component.timeChange.subscribe(time => updatedTime = time));
         component.ngOnChanges(changes);
         tick();
         expect(updatedTime).toEqual({time: 1, angle: 20});
@@ -196,7 +203,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
         it("should do nothing onMouseUp", fakeAsync(() => {
             let counter = 0;
 
-            component.timeChange.subscribe(() => counter++);
+            subscription.add(component.timeChange.subscribe(() => counter++));
             component.onMouseup(mouseClickEvent);
             component.selectTime(mouseMoveEvent);
             tick();
@@ -208,7 +215,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             const mouseCords: MouseEventInit = {clientX: 706, clientY: 20};
 
             component.faceTime = hourFaceTime;
-            component.timeChange.subscribe((time) => selectedTime = time);
+            subscription.add(component.timeChange.subscribe((time) => selectedTime = time));
             component.selectTime(new MouseEvent("mousemove", mouseCords));
             tick();
             expect(selectedTime.angle > 0 && selectedTime.angle <= 90).toBeTruthy();
@@ -219,7 +226,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             const mouseCords: MouseEventInit = {clientX: 703, clientY: 581};
 
             component.faceTime = hourFaceTime;
-            component.timeChange.subscribe((time) => selectedTime = time);
+            subscription.add(component.timeChange.subscribe((time) => selectedTime = time));
             component.selectTime(new MouseEvent("mousemove", mouseCords));
             tick();
             expect(selectedTime.angle > 90 && selectedTime.angle <= 180).toBeTruthy();
@@ -230,7 +237,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             const mouseCords: MouseEventInit = {clientX: 2, clientY: 500};
 
             component.faceTime = hourFaceTime;
-            component.timeChange.subscribe((time) => selectedTime = time);
+            subscription.add(component.timeChange.subscribe((time) => selectedTime = time));
             component.selectTime(new MouseEvent("mousemove", mouseCords));
             tick();
             expect(selectedTime.angle > 180 && selectedTime.angle <= 270).toBeTruthy();
@@ -241,7 +248,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             const mouseCords: MouseEventInit = {clientX: 20, clientY: 20};
 
             component.faceTime = hourFaceTime;
-            component.timeChange.subscribe((time) => selectedTime = time);
+            subscription.add(component.timeChange.subscribe((time) => selectedTime = time));
             component.selectTime(new MouseEvent("mousemove", mouseCords));
             tick();
             expect(selectedTime.angle > 270 && selectedTime.angle <= 360).toBeTruthy();
@@ -253,7 +260,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
 
             component.faceTime = hourFaceTime;
             component.format = 24;
-            component.timeChange.subscribe((time) => selectedTime = time);
+            subscription.add(component.timeChange.subscribe((time) => selectedTime = time));
 
             component.selectTime(new MouseEvent("mousemove", mouseCords));
             tick();
@@ -267,7 +274,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
 
             component.faceTime = minutesFaceTime;
             component.unit = NgxMatTimepickerUnits.MINUTE;
-            component.timeChange.subscribe((time) => selectedTime = time);
+            subscription.add(component.timeChange.subscribe((time) => selectedTime = time));
 
             component.selectTime(new MouseEvent("mousemove", mouseCords));
             tick();
@@ -280,7 +287,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
 
             hourFaceTime.forEach(h => h.disabled = true);
             component.faceTime = hourFaceTime;
-            component.timeChange.subscribe((time) => selectedTime = time);
+            subscription.add(component.timeChange.subscribe((time) => selectedTime = time));
 
             component.selectTime(new MouseEvent("mousemove", mouseCords));
             tick();
@@ -293,7 +300,7 @@ describe("NgxMatTimepickerFaceComponent", () => {
             component.faceTime = minutesFaceTime;
             component.unit = NgxMatTimepickerUnits.MINUTE;
 
-            component.timeSelected.subscribe((time) => expect(time).toBe(55));
+            subscription.add(component.timeSelected.subscribe((time) => expect(time).toBe(55)));
             component.onMouseup(mouseClickEvent);
             component.selectTime(new MouseEvent("click", mouseCords));
         }));

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
@@ -23,7 +23,7 @@ describe('NgxMatTimepickerControlComponent', () => {
                 NgxMatTimepickerTimeFormatterPipe
             ],
             schemas: [NO_ERRORS_SCHEMA]
-        }).compileComponents();
+        });
 
         fixture = TestBed.createComponent(NgxMatTimepickerControlComponent);
         component = fixture.componentInstance;

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
@@ -303,7 +303,7 @@ describe('NgxMatTimepickerControlComponent', () => {
     describe('onModelChange', () => {
 
         it('should parse value and set it to time property', () => {
-            const unparsedTime = DateTime.fromObject({minute: 10, numberingSystem: 'arab'}).toFormat('m');
+            const unparsedTime = DateTime.fromObject({minute: 10}, {numberingSystem: 'arab'}).toFormat('m');
             component.time = 5;
             component.timeUnit = NgxMatTimepickerUnits.MINUTE;
 

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NgxMatTimepickerControlComponent } from './ngx-mat-timepicker-control.component';
 import { NO_ERRORS_SCHEMA, SimpleChanges } from '@angular/core';
 import { NgxMatTimepickerUnits } from '../../../models/ngx-mat-timepicker-units.enum';
@@ -13,7 +14,10 @@ describe('NgxMatTimepickerControlComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NgxMatTimepickerModule.setLocale('ar-AE')],
+            imports: [
+                NgxMatTimepickerModule.setLocale('ar-AE'),
+                NoopAnimationsModule
+            ],
             providers: [
                 NgxMatTimepickerParserPipe,
                 NgxMatTimepickerTimeFormatterPipe

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-control/ngx-mat-timepicker-control.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NgxMatTimepickerControlComponent } from './ngx-mat-timepicker-control.component';
 import { NO_ERRORS_SCHEMA, SimpleChanges } from '@angular/core';
@@ -43,21 +43,21 @@ describe('NgxMatTimepickerControlComponent', () => {
             component.disabled = false;
         });
 
-        it('should increase time', async(() => {
+        it('should increase time', waitForAsync(() => {
             component.time = 1;
             component.timeChanged.subscribe(t => expect(t).toBe(2));
 
             component.increase();
         }));
 
-        it('should set time to min when increase time', async(() => {
+        it('should set time to min when increase time', waitForAsync(() => {
             component.time = 12;
             component.timeChanged.subscribe(t => expect(t).toBe(1));
 
             component.increase();
         }));
 
-        it('should change time to the nearest available next time', async(() => {
+        it('should change time to the nearest available next time', waitForAsync(() => {
             component.timeList = [
                 {time: 1, angle: 0},
                 {time: 2, angle: 0, disabled: true},
@@ -69,7 +69,7 @@ describe('NgxMatTimepickerControlComponent', () => {
             component.increase();
         }));
 
-        it('should not change time when all next time is disabled', async(() => {
+        it('should not change time when all next time is disabled', waitForAsync(() => {
             let counter = 0;
             component.time = 2;
             component.timeChanged.subscribe(() => counter++);
@@ -93,28 +93,28 @@ describe('NgxMatTimepickerControlComponent', () => {
             component.disabled = false;
         });
 
-        it('should decrease time', async(() => {
+        it('should decrease time', waitForAsync(() => {
             component.time = 2;
             component.timeChanged.subscribe(t => expect(t).toBe(1));
 
             component.decrease();
         }));
 
-        it('should set time to max when decrease time', async(() => {
+        it('should set time to max when decrease time', waitForAsync(() => {
             component.time = 1;
             component.timeChanged.subscribe(t => expect(t).toBe(3));
 
             component.decrease();
         }));
 
-        it('should time to nearest available previous time', async(() => {
+        it('should time to nearest available previous time', waitForAsync(() => {
             component.time = 3;
             component.timeChanged.subscribe((t) => expect(t).toBe(1));
 
             component.decrease();
         }));
 
-        it('should not change time when all previous time is disabled', async(() => {
+        it('should not change time when all previous time is disabled', waitForAsync(() => {
             let counter = 0;
             component.timeList = [
                 {time: 1, angle: 0, disabled: true},
@@ -148,7 +148,7 @@ describe('NgxMatTimepickerControlComponent', () => {
             defaultEvent = {type: 'keypress', stopPropagation: () => null};
         });
 
-        it('should set time to 14 when event fires with keycode 52', async(() => {
+        it('should set time to 14 when event fires with keycode 52', waitForAsync(() => {
             const event = {...defaultEvent, keyCode: 52}; // 4
             const expectedTime = 14;
 
@@ -205,14 +205,14 @@ describe('NgxMatTimepickerControlComponent', () => {
             ];
         });
 
-        it('should increase time by 1 when key down arrow up', async(() => {
+        it('should increase time by 1 when key down arrow up', waitForAsync(() => {
             const event = {...defaultEvent, key: 'ArrowUp'};
             component.time = 1;
             component.timeChanged.subscribe(time => expect(time).toBe(2));
             component.onKeydown(event);
         }));
 
-        it('should decrease time by 1 when key down arrow down', async(() => {
+        it('should decrease time by 1 when key down arrow down', waitForAsync(() => {
             const event: KeyboardEvent = {...defaultEvent, key: 'ArrowDown'} as KeyboardEvent;
             component.time = 2;
             component.timeChanged.subscribe(time => expect(time).toBe(1));
@@ -270,7 +270,7 @@ describe('NgxMatTimepickerControlComponent', () => {
             };
         });
 
-        it('should set time to 1 and emit it when current time is disabled', async(() => {
+        it('should set time to 1 and emit it when current time is disabled', waitForAsync(() => {
             component.time = 2;
             component.timeList = [
                 {time: 1, angle: 0, disabled: false},
@@ -333,7 +333,7 @@ describe('NgxMatTimepickerControlComponent', () => {
             expect(component.isFocused).toBeFalsy();
         });
 
-        it('should emit time when blur event fires and time was changed', async(() => {
+        it('should emit time when blur event fires and time was changed', waitForAsync(() => {
             const expectedTime = 10;
             component.time = expectedTime;
 

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { MatSelectChange } from '@angular/material/select';
 
 import { NgxMatTimepickerFieldComponent } from './ngx-mat-timepicker-field.component';
@@ -263,7 +263,7 @@ describe('NgxMatTimepickerFieldComponent', () => {
         });
     });
 
-    it('should update time and emit timeChanged event when timeSet called', async(() => {
+    it('should update time and emit timeChanged event when timeSet called', waitForAsync(() => {
         let time: string | null = null;
         const timeMock = '2:5 am';
         const expectedTime = '2:05 am';

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
@@ -15,16 +15,15 @@ describe('NgxMatTimepickerFieldComponent', () => {
     let fixture: ComponentFixture<NgxMatTimepickerFieldComponent>;
     let timer: string;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [NgxMatTimepickerFieldComponent],
             providers: [
                 {provide: NGX_MAT_TIMEPICKER_LOCALE, useValue: 'en-US'},
             ],
             schemas: [NO_ERRORS_SCHEMA]
-        })
-            .compileComponents();
-    }));
+        });
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(NgxMatTimepickerFieldComponent);

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatSelectChange } from '@angular/material/select';
 
 import { NgxMatTimepickerFieldComponent } from './ngx-mat-timepicker-field.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -12,7 +13,7 @@ import { NgxMatTimepickerUtils } from '../../utils/ngx-mat-timepicker.utils';
 describe('NgxMatTimepickerFieldComponent', () => {
     let component: NgxMatTimepickerFieldComponent;
     let fixture: ComponentFixture<NgxMatTimepickerFieldComponent>;
-    let timer;
+    let timer: string;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -29,7 +30,7 @@ describe('NgxMatTimepickerFieldComponent', () => {
         fixture = TestBed.createComponent(NgxMatTimepickerFieldComponent);
         component = fixture.componentInstance;
 
-        component.registerOnChange(function (time: number) {
+        component.registerOnChange(function (time: string) {
             timer = time;
         });
         fixture.detectChanges();
@@ -138,7 +139,7 @@ describe('NgxMatTimepickerFieldComponent', () => {
             component.max = max;
             component.minutesList = minutes;
             component.isTimeRangeSet = true;
-            component.changePeriod(period);
+            component.changePeriod({ value: period } as MatSelectChange);
 
             tick();
             expect(spy).toHaveBeenCalledTimes(0);
@@ -250,7 +251,7 @@ describe('NgxMatTimepickerFieldComponent', () => {
     it('should change period end emit timeChanged event', fakeAsync(() => {
         const expected = '12:00 PM';
         component.timeChanged.subscribe(time => expect(time).toBe(expected));
-        component.changePeriod(NgxMatTimepickerPeriods.PM);
+        component.changePeriod({ value: NgxMatTimepickerPeriods.PM } as MatSelectChange);
 
         tick();
         expect(component.period).toEqual(NgxMatTimepickerPeriods.PM);

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.spec.ts
@@ -1,56 +1,74 @@
-import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
-import {Component, ViewChild} from "@angular/core";
+import {TestBed, waitForAsync} from "@angular/core/testing";
+import {Component, Input, ViewChild} from "@angular/core";
+import {Subscription} from "rxjs";
 import {NgxMatTimepickerHoursFaceDirective} from "./ngx-mat-timepicker-hours-face.directive";
 
 @Component({
-    template: `<div ngxMatTimepickerHoursFace [format]="12">`
+    template: `<div ngxMatTimepickerHoursFace [format]="format">`
 })
-class Test12HoursComponent {
+class TestHostComponent {
+    @Input()
+    format: 12 | 24 = 24;
+
     @ViewChild(NgxMatTimepickerHoursFaceDirective)
     directive: NgxMatTimepickerHoursFaceDirective;
 }
 
-@Component({
-    template: `<div ngxMatTimepickerHoursFace [format]="24">`
-})
-class Test24HoursComponent {
-    @ViewChild(NgxMatTimepickerHoursFaceDirective)
-    directive: NgxMatTimepickerHoursFaceDirective;
-}
 
 describe("NgxMatTimepickerHoursFace", () => {
-    let fixture: ComponentFixture<Test12HoursComponent>;
-    let component12: Test12HoursComponent;
-    let component24: Test24HoursComponent;
+    function setup(options: {format: 12 | 24}) {
+        TestBed.configureTestingModule({
+            declarations: [
+                NgxMatTimepickerHoursFaceDirective,
+                TestHostComponent
+            ]
+        });
+        const fixture = TestBed.createComponent(TestHostComponent);
+        const component = fixture.componentInstance;
+        component.format = options.format;
+        fixture.detectChanges();
+        const directive = component.directive;
+
+        return {
+            directive,
+        }
+    }
+
+    let subscription: Subscription;
 
     beforeEach(() => {
-        fixture = TestBed.configureTestingModule({
-            declarations: [NgxMatTimepickerHoursFaceDirective, Test12HoursComponent, Test24HoursComponent],
-        }).createComponent(Test12HoursComponent);
+        subscription = new Subscription();
+    });
 
-        component12 = fixture.componentInstance;
-        component24 = TestBed.createComponent(Test24HoursComponent).componentInstance;
+    afterEach(() => {
+        subscription.unsubscribe();
     });
 
     it("should generate array with 12 items", () => {
-        expect(component12.directive.hoursList.length).toBe(12);
+        const {directive} = setup({ format: 12 });
+
+        expect(directive.hoursList.length).toBe(12);
     });
 
     it("should generate array with 24 items", () => {
-        expect(component24.directive.hoursList.length).toBe(24);
+        const {directive} = setup({ format: 24 });
+
+        expect(directive.hoursList.length).toBe(24);
     });
 
     it("should emit selected hour (12hr format)", waitForAsync(() => {
+        const {directive} = setup({ format: 12 });
         const time = 10;
 
-        component12.directive.hourSelected.subscribe(hour => expect(hour).toBe(time));
-        component12.directive.onTimeSelected(time);
+        subscription.add(directive.hourSelected.subscribe(hour => expect(hour).toBe(time)));
+        directive.onTimeSelected(time);
     }));
 
     it("should emit selected hour (24hr format)", waitForAsync(() => {
+        const {directive} = setup({ format: 24 });
         const time = 15;
 
-        component24.directive.hourSelected.subscribe(hour => expect(hour).toBe(time));
-        component24.directive.onTimeSelected(time);
+        subscription.add(directive.hourSelected.subscribe(hour => expect(hour).toBe(time)));
+        directive.onTimeSelected(time);
     }));
 });

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.spec.ts
@@ -1,23 +1,21 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import {Component} from "@angular/core";
+import {Component, ViewChild} from "@angular/core";
 import {NgxMatTimepickerHoursFaceDirective} from "./ngx-mat-timepicker-hours-face.directive";
 
 @Component({
-    template: "<h1>Test</h1>"
+    template: `<div ngxMatTimepickerHoursFace [format]="12">`
 })
-class Test12HoursComponent extends NgxMatTimepickerHoursFaceDirective {
-    constructor() {
-        super(12);
-    }
+class Test12HoursComponent {
+    @ViewChild(NgxMatTimepickerHoursFaceDirective)
+    directive: NgxMatTimepickerHoursFaceDirective;
 }
 
 @Component({
-    template: "<h1>Test</h1>"
+    template: `<div ngxMatTimepickerHoursFace [format]="24">`
 })
-class Test24HoursComponent extends NgxMatTimepickerHoursFaceDirective {
-    constructor() {
-        super(24);
-    }
+class Test24HoursComponent {
+    @ViewChild(NgxMatTimepickerHoursFaceDirective)
+    directive: NgxMatTimepickerHoursFaceDirective;
 }
 
 describe("NgxMatTimepickerHoursFace", () => {
@@ -27,7 +25,7 @@ describe("NgxMatTimepickerHoursFace", () => {
 
     beforeEach(() => {
         fixture = TestBed.configureTestingModule({
-            declarations: [Test12HoursComponent, Test24HoursComponent],
+            declarations: [NgxMatTimepickerHoursFaceDirective, Test12HoursComponent, Test24HoursComponent],
         }).createComponent(Test12HoursComponent);
 
         component12 = fixture.componentInstance;
@@ -35,24 +33,24 @@ describe("NgxMatTimepickerHoursFace", () => {
     });
 
     it("should generate array with 12 items", () => {
-        expect(component12.hoursList.length).toBe(12);
+        expect(component12.directive.hoursList.length).toBe(12);
     });
 
     it("should generate array with 24 items", () => {
-        expect(component24.hoursList.length).toBe(24);
+        expect(component24.directive.hoursList.length).toBe(24);
     });
 
     it("should emit selected hour (12hr format)", async(() => {
         const time = 10;
 
-        component12.hourSelected.subscribe(hour => expect(hour).toBe(time));
-        component12.onTimeSelected(time);
+        component12.directive.hourSelected.subscribe(hour => expect(hour).toBe(time));
+        component12.directive.onTimeSelected(time);
     }));
 
     it("should emit selected hour (24hr format)", async(() => {
         const time = 15;
 
-        component24.hourSelected.subscribe(hour => expect(hour).toBe(time));
-        component24.onTimeSelected(time);
+        component24.directive.hourSelected.subscribe(hour => expect(hour).toBe(time));
+        component24.directive.onTimeSelected(time);
     }));
 });

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-hours-face/ngx-mat-timepicker-hours-face.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {Component, ViewChild} from "@angular/core";
 import {NgxMatTimepickerHoursFaceDirective} from "./ngx-mat-timepicker-hours-face.directive";
 
@@ -40,14 +40,14 @@ describe("NgxMatTimepickerHoursFace", () => {
         expect(component24.directive.hoursList.length).toBe(24);
     });
 
-    it("should emit selected hour (12hr format)", async(() => {
+    it("should emit selected hour (12hr format)", waitForAsync(() => {
         const time = 10;
 
         component12.directive.hourSelected.subscribe(hour => expect(hour).toBe(time));
         component12.directive.onTimeSelected(time);
     }));
 
-    it("should emit selected hour (24hr format)", async(() => {
+    it("should emit selected hour (24hr format)", waitForAsync(() => {
         const time = 15;
 
         component24.directive.hourSelected.subscribe(hour => expect(hour).toBe(time));

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-period/ngx-mat-timepicker-period.component.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-period/ngx-mat-timepicker-period.component.spec.ts
@@ -1,3 +1,4 @@
+import { OverlayModule } from '@angular/cdk/overlay';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgxMatTimepickerPeriodComponent } from './ngx-mat-timepicker-period.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -14,6 +15,7 @@ describe('NgxMatTimepickerPeriodComponent', () => {
     beforeEach(() => {
         fixture = TestBed.configureTestingModule({
             declarations: [NgxMatTimepickerPeriodComponent],
+            imports: [OverlayModule],
             schemas: [NO_ERRORS_SCHEMA]
         }).createComponent(NgxMatTimepickerPeriodComponent);
 

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
@@ -29,7 +29,7 @@ describe("NgxMatTimepickerParserPipe", () => {
         const unparsedHours = Array(24).fill(0).map((v, i) => v + i);
 
         unparsedHours.forEach(hour => {
-            const unparsedHour = DateTime.fromObject({hour, numberingSystem: "arab"}).toFormat("H");
+            const unparsedHour = DateTime.fromObject({hour}, {numberingSystem: "arab"}).toFormat("H");
 
             expect(pipe.transform(unparsedHour, NgxMatTimepickerUnits.HOUR)).toBe(hour);
         });
@@ -39,7 +39,7 @@ describe("NgxMatTimepickerParserPipe", () => {
         const unparsedMinutes = Array(59).fill(0).map((v, i) => v + i);
 
         unparsedMinutes.forEach(minute => {
-            const unparsedMinute = DateTime.fromObject({minute, numberingSystem: "arab"}).toFormat("m");
+            const unparsedMinute = DateTime.fromObject({minute}, {numberingSystem: "arab"}).toFormat("m");
 
             expect(pipe.transform(unparsedMinute, NgxMatTimepickerUnits.MINUTE)).toBe(minute);
         });

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-parser.pipe.spec.ts
@@ -1,10 +1,11 @@
 import { NgxMatTimepickerParserPipe } from "./ngx-mat-timepicker-parser.pipe";
 import { NgxMatTimepickerUnits } from "../models/ngx-mat-timepicker-units.enum";
+import { NgxMatTimepickerLocaleService } from "../services/ngx-mat-timepicker-locale.service";
 import { DateTime } from "ts-luxon";
 
 describe("NgxMatTimepickerParserPipe", () => {
     const locale = "ar-AE";
-    const pipe = new NgxMatTimepickerParserPipe(locale);
+    const pipe = new NgxMatTimepickerParserPipe(new NgxMatTimepickerLocaleService(locale));
 
     it("should create an instance", () => {
         expect(pipe).toBeTruthy();

--- a/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/pipes/ngx-mat-timepicker-time-localizer.pipe.spec.ts
@@ -1,10 +1,11 @@
 import { NgxMatTimepickerTimeLocalizerPipe } from './ngx-mat-timepicker-time-localizer.pipe';
 import { NgxMatTimepickerUnits } from '../models/ngx-mat-timepicker-units.enum';
+import { NgxMatTimepickerLocaleService } from '../services/ngx-mat-timepicker-locale.service';
 import { DateTime } from "ts-luxon";
 
 describe('NgxMatTimepickerTimeLocalizerPipe', () => {
     const defaultLocale = 'en-US';
-    const pipe = new NgxMatTimepickerTimeLocalizerPipe(defaultLocale);
+    const pipe = new NgxMatTimepickerTimeLocalizerPipe(new NgxMatTimepickerLocaleService(defaultLocale));
 
     it('should create an instance', () => {
         expect(pipe).toBeTruthy();

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
@@ -127,7 +127,12 @@ export class NgxMatTimepickerAdapter {
         const hourCycle = format === 24 ? "h23" : "h12";
         const timeMask = (format === 24) ? NgxMatTimepickerFormat.TWENTY_FOUR_SHORT : NgxMatTimepickerFormat.TWELVE_SHORT;
 
-        return DateTime.fromFormat(time, timeMask).setLocale(locale).toLocaleString({
+        return DateTime.fromFormat(time, timeMask).reconfigure({
+            locale,
+            numberingSystem: opts.numberingSystem,
+            defaultToEN: opts.defaultToEN,
+            outputCalendar: opts.outputCalendar
+        }).toLocaleString({
             ...DateTime.TIME_SIMPLE,
             hourCycle
         });

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
@@ -134,7 +134,12 @@ export class NgxMatTimepickerAdapter {
     }
 
     private static _getLocaleOptionsByTime(time: string, opts: NgxMatTimepickerOptions): LocaleOptions {
-        const {numberingSystem, locale} = DateTime.local().setLocale(opts.locale).resolvedLocaleOptions();
+        const {numberingSystem, locale} = DateTime.local().reconfigure({
+            locale: opts.locale,
+            numberingSystem: opts.numberingSystem,
+            outputCalendar: opts.outputCalendar,
+            defaultToEN: opts.defaultToEN
+        }).resolvedLocaleOptions();
         const localeConfig: LocaleOptions = {
             numberingSystem: numberingSystem as NumberingSystem,
             locale

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-event.service.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-event.service.spec.ts
@@ -7,7 +7,7 @@ describe("NgxMatTimepickerService", () => {
         TestBed.configureTestingModule({
             providers: [NgxMatTimepickerEventService]
         });
-        eventService = TestBed.get(NgxMatTimepickerEventService);
+        eventService = TestBed.inject(NgxMatTimepickerEventService);
     });
 
 

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
@@ -128,14 +128,14 @@ describe('NgxMatTimepickerAdapter', () => {
             const expected = '١١:١١ ص';
             const actual = '11:11 am';
 
-            expect(NgxMatTimepickerAdapter.toLocaleTimeString(actual, {locale: 'ar-AE'})).toBe(expected);
+            expect(NgxMatTimepickerAdapter.toLocaleTimeString(actual, {locale: 'ar-AE', numberingSystem: 'arab'})).toBe(expected);
         });
 
         it('should convert provided time (en-US) to provided locale (ar-AE) in 24-hours format', () => {
             const expected = '٢١:١١';
             const actual = '21:11';
 
-            expect(NgxMatTimepickerAdapter.toLocaleTimeString(actual, {locale: 'ar-AE', format: 24})).toBe(expected);
+            expect(NgxMatTimepickerAdapter.toLocaleTimeString(actual, {locale: 'ar-AE', numberingSystem: 'arab', format: 24})).toBe(expected);
         });
     });
 

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-time-adapter.spec.ts
@@ -157,7 +157,7 @@ describe('NgxMatTimepickerAdapter', () => {
 
         it(`should convert time from 'arab' numbering system to 'latn' and return as string`, () => {
             const expected = '11:11 am';
-            const dateTime = DateTime.fromObject({hour: 11, minute: 11, numberingSystem: 'arab', locale: 'ar-AE'});
+            const dateTime = DateTime.fromObject({hour: 11, minute: 11 }, { numberingSystem: 'arab', locale: 'ar-AE'});
 
             expect(NgxMatTimepickerAdapter.fromDateTimeToString(dateTime, 12).toLowerCase()).toBe(expected);
         });

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.spec.ts
@@ -25,7 +25,7 @@ describe('NgxMatTimepickerService', () => {
             providers: [NgxMatTimepickerService]
         });
 
-        timepickerService = TestBed.get(NgxMatTimepickerService);
+        timepickerService = TestBed.inject(NgxMatTimepickerService);
         timepickerService.selectedHour.subscribe(hour => selectedHour = hour);
         timepickerService.selectedMinute.subscribe(minute => selectedMinute = minute);
         timepickerService.selectedPeriod.subscribe(period => selectedPeriod = period);

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.spec.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { Subscription } from 'rxjs';
 import { NgxMatTimepickerClockFace } from '../models/ngx-mat-timepicker-clock-face.interface';
 import { NgxMatTimepickerService } from './ngx-mat-timepicker.service';
 import { NgxMatTimepickerPeriods } from '../models/ngx-mat-timepicker-periods.enum';
@@ -19,16 +20,18 @@ describe('NgxMatTimepickerService', () => {
     let selectedHour: NgxMatTimepickerClockFace;
     let selectedMinute: NgxMatTimepickerClockFace;
     let selectedPeriod: NgxMatTimepickerPeriods;
+    let subscription: Subscription;
 
     beforeEach(() => {
+        subscription = new Subscription();
         TestBed.configureTestingModule({
             providers: [NgxMatTimepickerService]
         });
 
         timepickerService = TestBed.inject(NgxMatTimepickerService);
-        timepickerService.selectedHour.subscribe(hour => selectedHour = hour);
-        timepickerService.selectedMinute.subscribe(minute => selectedMinute = minute);
-        timepickerService.selectedPeriod.subscribe(period => selectedPeriod = period);
+        subscription.add(timepickerService.selectedHour.subscribe(hour => selectedHour = hour));
+        subscription.add(timepickerService.selectedMinute.subscribe(minute => selectedMinute = minute));
+        subscription.add(timepickerService.selectedPeriod.subscribe(period => selectedPeriod = period));
     });
 
     it('should set default hour on startup', () => {

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.ts
@@ -84,8 +84,7 @@ export class NgxMatTimepickerService {
     private _setDefaultTime(time: string, format: number) {
         const defaultTime = NgxMatTimepickerAdapter.parseTime(time, {format}).toJSDate();
 
-        // Check on null, because invalid date will be null
-        if (DateTime.fromJSDate(defaultTime) !== null) {
+        if (DateTime.fromJSDate(defaultTime).isValid) {
             const period = time.substr(time.length - 2).toUpperCase();
             const hour = defaultTime.getHours();
 

--- a/projects/ngx-mat-timepicker/src/test.ts
+++ b/projects/ngx-mat-timepicker/src/test.ts
@@ -1,6 +1,5 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'core-js/es7/reflect';
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';

--- a/projects/ngx-mat-timepicker/src/test.ts
+++ b/projects/ngx-mat-timepicker/src/test.ts
@@ -13,7 +13,13 @@ declare const require: any;
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
+  {
+    teardown: {
+      destroyAfterEach: true,
+      rethrowErrors: false,
+    }
+  }
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);


### PR DESCRIPTION
# Bug fixes
- Fix `NgxMatTimepickerAdapter.parseTime` when passing `numberingSystem`
- Fix `NgxMatTimepickerAdapter.toLocaleTimeString` when passing `numberingSystem`
- Handle invalid times in `NgxMatTimepickerService#setDefaultTimeIfAvailable`

# Tests
- Remove leftover import `core-js/es7/reflect`
- Disable Angular testing module rethrowing errors between runs because some tests don't handle tear down well
- Handle subscriptions in some unit tests
- Simplify test setup
- Migrate to `waitForAsync`
- Migrate to `TestBect.inject`
- Fix type issues
- Add missing providers and dependencies in unit tests
- Use host component in directive unit tests
- Correct a time assertion

# Other information
- There are still failing tests, for example in the pipe tests where `ts-luxon` doesn't seem to detect a numbering system based on a locale and there is no option to specify a numbering system.
- There are still flaky tests, in particular the `NgxMatTimepickerFaceComponent` test suite where click coordinates are problematic.