### PR TITLE
v16.0.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+#16.0.2
+* Fix change Hostlistener behaviour and add check after parse to handle invalid parsed DateTime (fixes [#70](https://github.com/tonysamperi/ngx-mat-timepicker/issues/70)) 
+
 #16.0.1
 * Don't emit unless both values are set in ngx-mat-timepicker-field (fixes [#71](https://github.com/tonysamperi/ngx-mat-timepicker/issues/71))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-timepicker",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "build": 0,
   "license": "MIT",
   "private": true,

--- a/projects/ngx-mat-timepicker-repo/src/app/app.module.ts
+++ b/projects/ngx-mat-timepicker-repo/src/app/app.module.ts
@@ -2,7 +2,7 @@ import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {BrowserModule} from "@angular/platform-browser";
 import {CommonModule} from "@angular/common";
 import {NgModule} from "@angular/core";
-import {FormsModule} from "@angular/forms";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 // MATERIAL
 import {MatButtonModule} from "@angular/material/button";
 import {MatCardModule} from "@angular/material/card";
@@ -37,6 +37,7 @@ import {NgxMatTimepickerLocaleOverrideService} from "./locale-override.service";
         BrowserAnimationsModule,
         CommonModule,
         FormsModule,
+        ReactiveFormsModule,
         //
         MatButtonModule,
         MatCardModule,

--- a/projects/ngx-mat-timepicker-repo/src/app/components/test/test.component.html
+++ b/projects/ngx-mat-timepicker-repo/src/app/components/test/test.component.html
@@ -34,24 +34,35 @@
 			<p>using <span class="mat-color-primary">default</span> palette (primary)</p>
 			<code-viewer>
 				<div class="example ngx-mtp-d-flex ngx-mtp-align-center ngx-mtp-flex-column">
-					<mat-form-field>
-						<input matInput
-							   name="selected_time_d"
+					<mat-form-field appearance="outline">
+						<mat-label>Enter Time</mat-label>
+						<input type="text"
+							   matInput
+							   [ngxMatTimepicker]="timepicker"
 							   [format]="24"
-							   [(ngModel)]="selectedTime"
-							   [ngxMatTimepicker]="pickerD"
-							   placeholder="23:59"
-							   readonly />
-						<mat-icon matSuffix
-								  (click)="pickerD.open()">watch_later
+							   [disableClick]="true"
+							   [formControl]="formControlItem" />
+
+						<mat-icon
+								matPrefix
+								[style.visibility]="formControlItem.value && !formControlItem.disabled ? 'visible' : 'hidden'"
+								(click)="onClear()">
+							close
 						</mat-icon>
+
+						<mat-icon
+								matSuffix
+								*ngIf="!formControlItem.disabled"
+								(click)="openFromIcon(timepicker)">schedule
+						</mat-icon>
+
+						<mat-error *ngIf="formControlItem.hasError('pattern')">Invalid format!</mat-error>
 					</mat-form-field>
-					<div class="ngx-mtp-box-bordered">
-						<small>ngx-mat-timepicker is here</small>
-						<ngx-mat-timepicker color="accent"
-											appendToInput
-                                            #pickerD></ngx-mat-timepicker>
-					</div>
+
+					<ngx-mat-timepicker
+                        #timepicker
+						[enableKeyboardInput]="true"></ngx-mat-timepicker>
+
 				</div>
 				<pre class="language-markup">
                     <code>

--- a/projects/ngx-mat-timepicker-repo/src/app/components/test/test.component.ts
+++ b/projects/ngx-mat-timepicker-repo/src/app/components/test/test.component.ts
@@ -1,6 +1,7 @@
-import {Component} from "@angular/core";
+import {Component, ViewChild} from "@angular/core";
+import {FormControl, Validators} from "@angular/forms";
 //
-import {NgxMatTimepickerLocaleService} from "ngx-mat-timepicker";
+import {NgxMatTimepickerComponent, NgxMatTimepickerLocaleService} from "ngx-mat-timepicker";
 //
 import {NgxMatTimepickerDemoComponent} from "../demo/demo.component";
 
@@ -13,8 +14,26 @@ import {NgxMatTimepickerDemoComponent} from "../demo/demo.component";
 })
 export class NgxMatTimepickerTestComponent extends NgxMatTimepickerDemoComponent {
 
+    formControlItem: FormControl = new FormControl("", [Validators.pattern(/([0-9]|[1-2]\d):[0-5]\d/)]);
+
+    @ViewChild("timepicker") timepicker: NgxMatTimepickerComponent;
+
     constructor(localeOverrideSrv: NgxMatTimepickerLocaleService) {
         super(localeOverrideSrv);
+    }
+
+    onClear() {
+        this.formControlItem.setValue(null);
+    }
+
+    onFieldBlur(): void {
+        this.formControlItem.valid && this.pickerFreeInput.updateTime(this.formControlItem.value);
+    }
+
+    openFromIcon(timepicker: { open: () => void }) {
+        if (!this.formControlItem.disabled) {
+            timepicker.open();
+        }
     }
 
 }

--- a/projects/ngx-mat-timepicker/package.json
+++ b/projects/ngx-mat-timepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-timepicker",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "license": "MIT",
   "description": "ngx-mat-timepicker is an Angular material 9+ extension to add time pickers!",
   "homepage": "https://tonysamperi.github.io/ngx-mat-timepicker",

--- a/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.ts
+++ b/projects/ngx-mat-timepicker/src/lib/directives/ngx-mat-timepicker.directive.ts
@@ -194,9 +194,9 @@ export class NgxMatTimepickerDirective implements ControlValueAccessor, OnDestro
     }
 
     @HostListener("change", ["$event"])
-    updateValue(value: string) {
-        this.value = value;
-        this._onChange(value);
+    updateValue(e: Event) {
+        this.value = (e.target as HTMLInputElement).value;
+        this._onChange(this.value);
     }
 
     writeValue(value: string): void {

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker-adapter.ts
@@ -36,6 +36,9 @@ export class NgxMatTimepickerAdapter {
             return "Invalid Time";
         }
         const parsedTime = this.parseTime(time, opts).setLocale(this.defaultLocale);
+        if (!parsedTime.isValid) {
+            return "Invalid time";
+        }
         const isTwelve = !this.isTwentyFour(opts.format as NgxMatTimepickerFormatType);
         if (isTwelve) {
             return parsedTime.toLocaleString({


### PR DESCRIPTION
* Fix change Hostlistener behaviour and add check after parse to handle invalid parsed DateTime (fixes [#70](https://github.com/tonysamperi/ngx-mat-timepicker/issues/70))