### PR TITLE
exporting  NgxMatTimepickerFormatType from public-api.ts

### DIFF
--- a/projects/ngx-mat-timepicker/src/public-api.ts
+++ b/projects/ngx-mat-timepicker/src/public-api.ts
@@ -7,6 +7,7 @@ export {NgxMatTimepickerDirective} from "./lib/directives/ngx-mat-timepicker.dir
 export {NgxMatTimepickerToggleIconDirective} from "./lib/directives/ngx-mat-timepicker-toggle-icon.directive";
 // MODELS
 export {NgxMatTimepickerConfig} from "./lib/models/ngx-mat-timepicker-config.interface";
+export {NgxMatTimepickerFormatType} from "./lib/models/ngx-mat-timepicker-format.type";
 // SERVICES
 export {NgxMatTimepickerLocaleService} from "./lib/services/ngx-mat-timepicker-locale.service";
 //


### PR DESCRIPTION
**NgxMatTimepickerFormatType** is the correct typing of the format input of **ngx-mat-timepicker-field.**

It has to be public because it is the input type of a public component.