### PR TITLE
fix: ControlValueAccessor become more touchy

### DIFF
--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-field/ngx-mat-timepicker-field.component.ts
@@ -238,6 +238,7 @@ export class NgxMatTimepickerFieldComponent implements OnInit, OnDestroy, Contro
     }
 
     registerOnTouched(_fn_: any): void {
+        this._onTouched = fn;
     }
 
     setDisabledState(isDisabled: boolean): void {
@@ -273,6 +274,7 @@ export class NgxMatTimepickerFieldComponent implements OnInit, OnDestroy, Contro
         const localTime = NgxMatTimepickerAdapter.toLocaleTimeString(time, {format: this.format, locale: this._locale});
 
         this._onChange(localTime);
+        this._onTouched(localTime);
         this.timeChanged.emit(localTime);
     }
 
@@ -306,6 +308,9 @@ export class NgxMatTimepickerFieldComponent implements OnInit, OnDestroy, Contro
     private _onChange: (value: string) => void = () => {
     };
 
+    private _onTouched: (value: string) => void = () => {
+    };
+    
     private _resetTime(): void {
         this._timepickerService.hour = {angle: 0, time: null};
         this._timepickerService.minute = {angle: 0, time: null};


### PR DESCRIPTION
The form surrounding the control implementing CVA was not properly showing value updates performed with this.form.setValue (which translates to the write-function of CVA).

CVA (now?) requires the form controls to handle the touch event stuff.