### PR TITLE
fix: jumping terminal

### DIFF
--- a/projects/ngx-mat-timepicker-repo/src/app/components/demo/demo.component.scss
+++ b/projects/ngx-mat-timepicker-repo/src/app/components/demo/demo.component.scss
@@ -203,3 +203,7 @@ footer {
 	padding: 0;
 	margin: 0;
 }
+
+.terminal ul li {
+	line-height: 1.3rem;
+}


### PR DESCRIPTION
The animated terminal causes a small page resize. 
This change should keep the terminal line height consistent.