### PR TITLE
added FormControl demo

### DIFF
--- a/projects/ngx-mat-timepicker-repo/src/app/components/demo/demo.component.html
+++ b/projects/ngx-mat-timepicker-repo/src/app/components/demo/demo.component.html
@@ -248,6 +248,33 @@
             </code-viewer>
         </div>
         <div>
+            <h2>reactive ngx-mat-timepicker-field form control</h2>
+            <p>using <span class="mat-color-warn">warn</span> palette</p>
+            <code-viewer>
+                <div class="example ngx-mtp-d-flex ngx-mtp-align-center ngx-mtp-flex-column">
+                    <p><strong>format = 24</strong></p>
+                    <form [formGroup]="reactiveForm">
+                    <ngx-mat-timepicker-field color="warn"
+                                              [format]="24"
+                                              [formControl]="timeValue" />
+                    <button mat-raised-button
+                            class="ngx-mtp-margin-top ngx-mtp-margin-bottom ngx-mtp-d-inline-block"
+                            (click)="updateTimeValue()"
+                            color="primary">
+                        Update Time
+                    </button>
+                    <p>form control value {{ timeValue.value }}</p>
+                </form>
+                </div>
+                <pre class="language-markup">
+                    <code>
+ &lt;ngx-mat-timepicker-field color="warn"
+                           [format]="24"&gt;&lt;/ngx-mat-timepicker-field&gt;
+                    </code>
+                </pre>
+            </code-viewer>
+        </div>
+        <div>
             <h2>Input with *ngIf</h2>
             <p>using <strong>*ngIf</strong> to show/hide only the input, but not the ngx-mat-timepicker</p>
             <p><small>Before v 9.0.3, inputs weren't detached when destroyed, so you needed to destroy the

--- a/projects/ngx-mat-timepicker-repo/src/app/components/demo/demo.component.ts
+++ b/projects/ngx-mat-timepicker-repo/src/app/components/demo/demo.component.ts
@@ -1,7 +1,7 @@
-import {Component, OnInit, ViewChild} from "@angular/core";
+import {Component, OnInit, ViewChild, inject} from "@angular/core";
 import {MatInputModule} from "@angular/material/input";
 import {MatFormFieldModule} from "@angular/material/form-field";
-import {FormsModule} from "@angular/forms";
+import {FormControl, FormGroup, FormsModule, NonNullableFormBuilder, ReactiveFormsModule} from "@angular/forms";
 import {NgFor, NgIf} from "@angular/common";
 import {MatMenuModule} from "@angular/material/menu";
 import {MatButtonModule} from "@angular/material/button";
@@ -33,6 +33,10 @@ interface NgxMatTimepickerTheme {
 
 const pkgName = "ngx-mat-timepicker";
 
+interface IReactiveFormDemo {
+    timeValue: FormControl<string>;
+}
+
 @Component({
     // tslint:disable-next-line:component-selector
     selector: "app-demo",
@@ -46,6 +50,7 @@ const pkgName = "ngx-mat-timepicker";
         NgFor,
         NgIf,
         FormsModule,
+        ReactiveFormsModule,
         CodeViewerComponent,
         MatFormFieldModule,
         MatInputModule,
@@ -107,9 +112,25 @@ export class NgxMatTimepickerDemoComponent implements OnInit {
     timeRegex: RegExp = /([0-9]|1\d):[0-5]\d (AM|PM)/;
     year: number = new Date().getFullYear();
 
+    reactiveForm: FormGroup<IReactiveFormDemo>;
+
+    get timeValue(): FormControl<string> {
+        return this.reactiveForm.controls.timeValue;
+    }
+
     private _nextLocale: number = 0;
 
     constructor(private _localeOverrideSrv: NgxMatTimepickerLocaleService) {
+        const fb = inject(NonNullableFormBuilder);
+        this.reactiveForm = fb.group<IReactiveFormDemo>({
+            timeValue:fb.control<string>('23:11',{
+                updateOn: 'change'
+            })
+        });
+    }
+
+    updateTimeValue(): void {
+        this.timeValue.setValue('12:34');
     }
 
     debug(): void {


### PR DESCRIPTION
Hi!

I added a quick demo on usage of ngx-mat-timepicker-field as a FormControl via ControlValueAccessor.

This step seems to be required to show that changes of the value of the FormControl are not properly reflected in the ngx-mat-timepicker-field.  (click "Update Time" button)

Core reason: The displayed value is now bound to the hour$/minute$ Observable of the NgxMatTimepickerService.

What is missing: Acknowledging the writeValue() function as a often triggered source of value changes.



